### PR TITLE
Add mvtnorm dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     ggplot2,
     ggnewscale,
     dplyr,
+    mvtnorm,
     magrittr,
     ieugwasr (>= 0.1.4),
     readr,


### PR DESCRIPTION
It's used in `cal_likelihood.R` [here](https://github.com/YangLabHKUST/MR-APSS/blob/ddb918905fe3ffedab46f38454c72cec725643b9/R/cal_likelihood.R#L7)